### PR TITLE
Add `elbowroom` option

### DIFF
--- a/autosize-input.js
+++ b/autosize-input.js
@@ -65,6 +65,8 @@
       ghost.style.cssText += elementCssText
       ghost.innerHTML = escape(str)
       var width = window.getComputedStyle(ghost).width
+      if(options.elbowroom)
+        width = (parseInt(width.replace(/px/g, ''), 10) + options.elbowroom) + 'px'
       element.style.width = width
       return width
     }


### PR DESCRIPTION
Make it possible to add some pixels to the calculation manually, for those odd cases where the automatic calculation is slightly off.